### PR TITLE
Fix predictedUnavailableUntil

### DIFF
--- a/server/controllers/RecommendationsController.ts
+++ b/server/controllers/RecommendationsController.ts
@@ -42,19 +42,17 @@ export const getRecommendation = async (
       return;
     }
 
-    // If floor specified, subtract time between floors from predictedUnavailableUntil and re-sort
-    // Choose seat that has the earliest predictedUnavailableUntil
+    // If floor specified, the earliest time we can get an empty seat is
+    // the max of currentTime+movementTime and predictedUnavailableUntil
+    // choose seat that has the earliest predictedUnavailableUntil
     if (floor) {
       const currentTime = new Date();
       for (let i in seats) {
         const predictedUnavailableUntil = seats[i].predictedUnavailableUntil;
         const movementTime = Math.abs(floor - seats[i].floor) * floorMovementTime * 60000;
-        if (predictedUnavailableUntil.getTime()<currentTime.getTime() - 6 * 3600000) {
-          seats[i].predictedUnavailableUntil = new Date (currentTime.getTime() + movementTime)
-        }
-        else {
-          seats[i].predictedUnavailableUntil = new Date(predictedUnavailableUntil.getTime() + movementTime);
-        }
+
+        seats[i].predictedUnavailableUntil = new Date(Math.max(currentTime.getTime() + movementTime,
+            predictedUnavailableUntil.getTime()));
       }
 
       seats.sort((a, b) => {


### PR DESCRIPTION
If the floor is specified, the earliest we can get an empty seat is earliestSeatingTime = max(currentTime+movementTime, predictedUnavailableUntil)

So we sort by this and return the seat with the lowest earliestSeatingTime